### PR TITLE
Add PR URL information to the parts .yaml file

### DIFF
--- a/SS14.Changelog.Tests/ChangelogParseTest.cs
+++ b/SS14.Changelog.Tests/ChangelogParseTest.cs
@@ -22,12 +22,13 @@ Did stuff!
 ";
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
-            var pr = new GHPullRequest(true, text, new GHUser("PJB"), time, new GHPullRequestBase("master"), 123);
+            var pr = new GHPullRequest(true, text, new GHUser("PJB"), time, new GHPullRequestBase("master"), 123, "https://www.example.com");
             var parsed = WebhookController.ParsePRBody(pr);
 
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.Author, Is.EqualTo("Ev1__l P-JB2323"));
             Assert.That(parsed.Time, Is.EqualTo(time));
+            Assert.That(parsed.Url, Is.EqualTo("https://www.example.com"));
             Assert.That(parsed.Changes, Is.EquivalentTo(new[]
             {
                 (ChangelogEntryType.Add, "Did the thing"),
@@ -50,12 +51,13 @@ Did stuff!
 ";
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
-            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123, "https://www.example.com");
             var parsed = WebhookController.ParsePRBody(pr);
 
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.Author, Is.EqualTo("Swept"));
             Assert.That(parsed.Time, Is.EqualTo(time));
+            Assert.That(parsed.Url, Is.EqualTo("https://www.example.com"));
             Assert.That(parsed.Changes, Is.EquivalentTo(new[]
             {
                 (ChangelogEntryType.Add, "Did the thing"),
@@ -78,12 +80,13 @@ Did stuff!
 ";
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
-            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123, "https://www.example.com");
             var parsed = WebhookController.ParsePRBody(pr);
 
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.Author, Is.EqualTo("Swept"));
             Assert.That(parsed.Time, Is.EqualTo(time));
+            Assert.That(parsed.Url, Is.EqualTo("https://www.example.com"));
             Assert.That(parsed.Changes, Is.EquivalentTo(new[]
             {
                 (ChangelogEntryType.Add, "Did the thing"),
@@ -98,12 +101,13 @@ Did stuff!
                 "Makes it possible to repair things with a welder.\r\n\r\n**Changelog**\r\n:cl: AJCM\r\n- add: Makes gravity generator and windows repairable with a lit welding tool \r\n\r\n";
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
-            var pr = new GHPullRequest(true, text, new GHUser("AJCM-Git"), time, new GHPullRequestBase("master"), 123);
+            var pr = new GHPullRequest(true, text, new GHUser("AJCM-Git"), time, new GHPullRequestBase("master"), 123, "https://www.example.com");
             var parsed = WebhookController.ParsePRBody(pr);
 
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.Author, Is.EqualTo("AJCM"));
             Assert.That(parsed.Time, Is.EqualTo(time));
+            Assert.That(parsed.Url, Is.EqualTo("https://www.example.com"));
             Assert.That(parsed.Changes, Is.EquivalentTo(new[]
             {
                 (ChangelogEntryType.Add, "Makes gravity generator and windows repairable with a lit welding tool")

--- a/SS14.Changelog/ChangelogData.cs
+++ b/SS14.Changelog/ChangelogData.cs
@@ -16,6 +16,7 @@ namespace SS14.Changelog
         public ImmutableArray<(ChangelogEntryType, string)> Changes { get; }
         public DateTimeOffset Time { get; }
         public int Number { get; init; }
+        public string Url { get; init; }
     }
     
     public enum ChangelogEntryType

--- a/SS14.Changelog/Controllers/WebhookController.cs
+++ b/SS14.Changelog/Controllers/WebhookController.cs
@@ -184,7 +184,8 @@ namespace SS14.Changelog.Controllers
 
             return new ChangelogData(author, entries.ToImmutableArray(), pr.MergedAt ?? DateTimeOffset.Now)
             {
-                Number = pr.Number
+                Number = pr.Number,
+                Url = pr.Url
             };
         }
     }

--- a/SS14.Changelog/GitHubData.cs
+++ b/SS14.Changelog/GitHubData.cs
@@ -26,7 +26,7 @@ namespace SS14.Changelog
     public sealed record GHPullRequest
     {
         [JsonConstructor]
-        public GHPullRequest(bool merged, string body, GHUser user, DateTimeOffset? mergedAt, GHPullRequestBase @base, int number)
+        public GHPullRequest(bool merged, string body, GHUser user, DateTimeOffset? mergedAt, GHPullRequestBase @base, int number, string url)
         {
             Merged = merged;
             Body = body;
@@ -34,6 +34,7 @@ namespace SS14.Changelog
             MergedAt = mergedAt;
             Base = @base;
             Number = number;
+            Url = url;
         }
 
         public bool Merged { get; }
@@ -43,6 +44,7 @@ namespace SS14.Changelog
         public DateTimeOffset? MergedAt { get; }
         public GHPullRequestBase Base { get; }
         public int Number { get; }
+        public string Url { get; }
     }
 
     public sealed record GHPullRequestBase

--- a/SS14.Changelog/Services/ChangelogService.cs
+++ b/SS14.Changelog/Services/ChangelogService.cs
@@ -294,6 +294,7 @@ namespace SS14.Changelog.Services
                 {
                     {"author", Quoted(data.Author)},
                     {"time", Quoted(data.Time.ToString("O"))},
+                    {"url", Quoted(data.Url)},
                     {
                         "changes",
                         new YamlSequenceNode(


### PR DESCRIPTION
Will enable the changelog display options (Discord bot, RSS etc.) to include URL links directly to the Github PRs.

Also includes updated tests, which have run successfully.