### PR TITLE
Correct header regex

### DIFF
--- a/SS14.Changelog/Controllers/WebhookController.cs
+++ b/SS14.Changelog/Controllers/WebhookController.cs
@@ -23,7 +23,7 @@ namespace SS14.Changelog.Controllers
         private static readonly Regex IsChangelogFileRegex = new Regex(@"^Resources/Changelog/Parts/.*\.yml$");
 
         private static readonly Regex ChangelogHeaderRegex =
-            new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ]+)?\s+$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+            new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
         private static readonly Regex ChangelogEntryRegex =
             new Regex(@"^ *[*-]? *(add|remove|tweak|fix|bug|bugfix): *([^\n\r]+)\r?$", RegexOptions.IgnoreCase);


### PR DESCRIPTION
All the tests were failing because of this regex.

From the looks of it, it was trying to match whitespaces after the header. That is not guaranteed to exist in changelogs. I changed it to try none or more.

For some reason everything still works in production? This is puzzling so before merging my pr please double check that I am not insane.