### PR TITLE
Make header accept comma

### DIFF
--- a/SS14.Changelog/Controllers/WebhookController.cs
+++ b/SS14.Changelog/Controllers/WebhookController.cs
@@ -23,7 +23,7 @@ namespace SS14.Changelog.Controllers
         private static readonly Regex IsChangelogFileRegex = new Regex(@"^Resources/Changelog/Parts/.*\.yml$");
 
         private static readonly Regex ChangelogHeaderRegex =
-            new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+            new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ,]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
         private static readonly Regex ChangelogEntryRegex =
             new Regex(@"^ *[*-]? *(add|remove|tweak|fix|bug|bugfix): *([^\n\r]+)\r?$", RegexOptions.IgnoreCase);

--- a/SS14.Changelog/Controllers/WebhookController.cs
+++ b/SS14.Changelog/Controllers/WebhookController.cs
@@ -23,7 +23,7 @@ namespace SS14.Changelog.Controllers
         private static readonly Regex IsChangelogFileRegex = new Regex(@"^Resources/Changelog/Parts/.*\.yml$");
 
         private static readonly Regex ChangelogHeaderRegex =
-            new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ,]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+            new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ,&]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
         private static readonly Regex ChangelogEntryRegex =
             new Regex(@"^ *[*-]? *(add|remove|tweak|fix|bug|bugfix): *([^\n\r]+)\r?$", RegexOptions.IgnoreCase);


### PR DESCRIPTION
Makes the header for commits accept commas.

People put commas to separate names in the changelog sometimes. Those don't get captured because comma is not in the capture group.