### PR TITLE
Add label names to changelog information

### DIFF
--- a/SS14.Changelog.Tests/ChangelogParseTest.cs
+++ b/SS14.Changelog.Tests/ChangelogParseTest.cs
@@ -31,7 +31,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("PJB"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {
@@ -70,7 +70,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {
@@ -109,7 +109,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {
@@ -138,7 +138,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("AJCM-Git"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {
@@ -174,7 +174,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {
@@ -215,7 +215,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { ExtraCategories = new []{"Admin"}});
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { ExtraCategories = ["Admin"], IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {
@@ -260,7 +260,7 @@ namespace SS14.Changelog.Tests
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
                 "https://www.example.com", [ new GHLabel("test_label")]);
-            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { ExtraCategories = new []{"Admin"}});
+            var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { ExtraCategories = ["Admin"], IncludedLabels = ["test_label"] });
 
             Assert.Multiple(() =>
             {

--- a/SS14.Changelog.Tests/ChangelogParseTest.cs
+++ b/SS14.Changelog.Tests/ChangelogParseTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
 using SS14.Changelog.Configuration;
@@ -29,7 +30,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("PJB"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
 
             Assert.Multiple(() =>
@@ -49,6 +50,7 @@ namespace SS14.Changelog.Tests
                         new(ChangelogData.ChangeType.Fix, "B"),
                         new(ChangelogData.ChangeType.Fix, "C"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
 
@@ -67,7 +69,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
 
             Assert.Multiple(() =>
@@ -84,6 +86,7 @@ namespace SS14.Changelog.Tests
                         new(ChangelogData.ChangeType.Add, "Did the thing"),
                         new(ChangelogData.ChangeType.Remove, "Removed the thing"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
 
@@ -105,7 +108,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
 
             Assert.Multiple(() =>
@@ -122,6 +125,7 @@ namespace SS14.Changelog.Tests
                         new(ChangelogData.ChangeType.Add, "Did the thing"),
                         new(ChangelogData.ChangeType.Remove, "Removed the thing"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
 
@@ -133,7 +137,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("AJCM-Git"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
 
             Assert.Multiple(() =>
@@ -149,6 +153,7 @@ namespace SS14.Changelog.Tests
                     {
                         new(ChangelogData.ChangeType.Add, "Makes gravity generator and windows repairable with a lit welding tool"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
 
@@ -168,7 +173,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig());
 
             Assert.Multiple(() =>
@@ -185,6 +190,7 @@ namespace SS14.Changelog.Tests
                         new(ChangelogData.ChangeType.Add, "Did the thing"),
                         new(ChangelogData.ChangeType.Remove, "Removed the thing"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
 
@@ -208,7 +214,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { ExtraCategories = new []{"Admin"}});
 
             Assert.Multiple(() =>
@@ -233,6 +239,7 @@ namespace SS14.Changelog.Tests
                         new(ChangelogData.ChangeType.Add, "Did more thing"),
                         new(ChangelogData.ChangeType.Remove, "Removed more thing"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
 
@@ -252,7 +259,7 @@ namespace SS14.Changelog.Tests
 
             var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
             var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
-                "https://www.example.com");
+                "https://www.example.com", [ new GHLabel("test_label")]);
             var parsed = WebhookController.ParsePRBody(pr, new ChangelogConfig { ExtraCategories = new []{"Admin"}});
 
             Assert.Multiple(() =>
@@ -270,6 +277,7 @@ namespace SS14.Changelog.Tests
                         new(ChangelogData.ChangeType.Remove, "Removed the thing"),
                         new(ChangelogData.ChangeType.Add, "WOW"),
                     }));
+                Assert.That(parsed.Labels, Is.EqualTo(new string[] { "test_label" }));
             });
         }
     }

--- a/SS14.Changelog/ChangelogData.cs
+++ b/SS14.Changelog/ChangelogData.cs
@@ -19,6 +19,7 @@ namespace SS14.Changelog
         public DateTimeOffset Time { get; }
         public int Number { get; init; }
         public required string HtmlUrl { get; init; }
+        public ImmutableArray<string> Labels { get; init; }
 
         public sealed record CategoryData(string Category, ImmutableArray<Change> Changes);
 

--- a/SS14.Changelog/Configuration/ChangelogConfig.cs
+++ b/SS14.Changelog/Configuration/ChangelogConfig.cs
@@ -38,5 +38,10 @@ namespace SS14.Changelog.Configuration
         /// and are written to a separate <c>Category.yml</c> file in the changelog data.
         /// </remarks>
         public string[] ExtraCategories { get; set; } = Array.Empty<string>();
+        
+        /// <summary>
+        /// The names of labels which should be checked for and included in the changelog, if they exist on the related PR.
+        /// </summary>
+        public string[] IncludedLabels { get; set; } = Array.Empty<string>();
     }
 }

--- a/SS14.Changelog/Controllers/WebhookController.cs
+++ b/SS14.Changelog/Controllers/WebhookController.cs
@@ -173,7 +173,8 @@ namespace SS14.Changelog.Controllers
             var changelogBody = body.Substring(match.Index + match.Length);
             var labels = new List<string>();
             foreach (var label in pr.Labels)
-                labels.Add(label.Name);
+                if (config.IncludedLabels.Contains(label.Name))
+                    labels.Add(label.Name);
 
             var currentCategory = ChangelogData.MainCategory;
             var entries = new List<(string, ChangelogData.Change)>();

--- a/SS14.Changelog/Controllers/WebhookController.cs
+++ b/SS14.Changelog/Controllers/WebhookController.cs
@@ -171,6 +171,9 @@ namespace SS14.Changelog.Controllers
 
             var author = match.Groups[1].Success ? match.Groups[1].Value.Trim() : pr.User.Login;
             var changelogBody = body.Substring(match.Index + match.Length);
+            var labels = new List<string>();
+            foreach (var label in pr.Labels)
+                labels.Add(label.Name);
 
             var currentCategory = ChangelogData.MainCategory;
             var entries = new List<(string, ChangelogData.Change)>();
@@ -217,7 +220,8 @@ namespace SS14.Changelog.Controllers
             return new ChangelogData(author, finalCategories, pr.MergedAt ?? DateTimeOffset.Now)
             {
                 Number = pr.Number,
-                HtmlUrl = pr.Html_url
+                HtmlUrl = pr.Html_url,
+                Labels = labels.ToImmutableArray(),
             };
         }
     }

--- a/SS14.Changelog/GitHubData.cs
+++ b/SS14.Changelog/GitHubData.cs
@@ -18,11 +18,14 @@ namespace SS14.Changelog
         DateTimeOffset? MergedAt,
         GHPullRequestBase Base,
         int Number,
-        string Html_url);
+        string Html_url,
+        ImmutableArray<GHLabel> Labels);
 
     public sealed record GHPullRequestBase(string Ref);
 
     public sealed record GHUser(string Login);
+    public sealed record GHLabel(string Name);
+
 
     public sealed record GHPushEvent(ImmutableArray<GHPushedCommit> Commits, string Ref);
 


### PR DESCRIPTION
This PR is a predecessor for adding changelog information based on Github labels, as described in https://github.com/space-wizards/docs/pull/494. This is so that processes using the changelog info can grab it and use it to modify the changelog in whatever way is desired. The label names are included as a string array.

<sup>also please help me test this, i do not know how to set that up as a non-fork dev augh</sup>